### PR TITLE
Fixed NSObject error

### DIFF
--- a/SKYLINK.framework/Versions/A/Headers/SKYLINKConnection.h
+++ b/SKYLINK.framework/Versions/A/Headers/SKYLINKConnection.h
@@ -6,7 +6,7 @@
 //
 
 #import <CoreGraphics/CoreGraphics.h>
-
+#import <Foundation/Foundation.h>
 
 /**
  @typedef SKYLINKAssetType


### PR DESCRIPTION
There is an error when trying to use the SDK, this error is due to Foundation not being imported correctly.